### PR TITLE
Release 0.4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+ language: node_js
+ node_js:
+   - "6"
+install:
+  - npm install
+script:
+  - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+* [MAINTENANCE] update links after transferring the repository to the `Deskpro` organization
+* [MAINTENANCE] enable travis ci integration
+
 ## v0.4.4 - 2017-07-06
 * [FIX] The algorithm that resolves the source for the application manifest does not choose manifest.json when that file is present
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dpat
+# dpat &middot; [![Build Status](https://travis-ci.org/deskpro/deskproapps-dpat.svg?branch=master)](https://travis-ci.org/deskpro/deskproapps-dpat)
 Deskpro Apps Tool
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ It is best to install this package globally
 
 ## Documentation
 
-View online docs at: https://deskproapps.github.io/dpat/
+View online docs at: https://deskpro.github.io/deskproapps-dpat/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DeskproApps/dpat.git"
+    "url": "git+https://github.com/Deskpro/deskproapps-dpat.git"
   },
   "keywords": [
     "deskpro",
@@ -24,9 +24,9 @@
   "author": "DeskPRO Ltd.",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/DeskproApps/dpat/issues"
+    "url": "https://github.com/Deskpro/deskproapps-dpat/issues"
   },
-  "homepage": "https://github.com/DeskproApps/dpat#readme",
+  "homepage": "https://github.com/Deskpro/deskproapps-dpat#readme",
   "dependencies": {
     "archiver": "1.3.0",
     "babel-cli": "6.24.1",


### PR DESCRIPTION
- update links after transferring the repository to the `Deskpro` organization
- enable travis ci integration