### PR TITLE
Make the children inherit the parent environment

### DIFF
--- a/src/main/javascript/Project/DeskproProject.js
+++ b/src/main/javascript/Project/DeskproProject.js
@@ -175,10 +175,16 @@ Run the following commands manually: mkdir -p ${distFolder}
     const projectLocalConfig = path.resolve(projectRoot, "src", "webpack", "webpack.config-distribution.js");
     const webpackConfig = fs.existsSync(projectLocalConfig) ? projectLocalConfig : defaultWebpackConfig;
 
+    const env = Object.assign(
+      {},
+      process.env,
+      { DP_PROJECT_ROOT: projectRoot }
+    );
+
     const devServer = spawnSync(
       webpackPath
       , ['--config', webpackConfig, '--env.DP_PROJECT_ROOT', projectRoot]
-      , { cwd: projectRoot, stdio: 'inherit', env: { DP_PROJECT_ROOT: projectRoot, NODE_PATH: process.env.NODE_PATH } }
+      , { cwd: projectRoot, stdio: 'inherit', env: env }
     );
 
     if (devServer.status === 0) {
@@ -224,13 +230,19 @@ Run the following commands manually: mkdir -p ${distFolder}
     const projectLocalConfig = path.resolve(projectRoot, "src", "webpack", "webpack.config-development.js");
     const webpackConfig = fs.existsSync(projectLocalConfig) ? projectLocalConfig : defaultWebpackConfig;
 
+      const env = Object.assign(
+        {},
+        process.env,
+        { DP_PROJECT_ROOT: projectRoot }
+      );
+
       const devServer = spawn(
         webpackDevServerPath
           , [
               '--config', webpackConfig,
               '--env.DP_PROJECT_ROOT', projectRoot
           ]
-          , { cwd: projectRoot, stdio: 'inherit', env: { DP_PROJECT_ROOT: projectRoot, NODE_PATH: process.env.NODE_PATH } }
+          , { cwd: projectRoot, stdio: 'inherit', env: env }
       );
 
       devServer.on('exit', (code) => {


### PR DESCRIPTION
When a process is created by `spawn`/`spawnSync` with a specific
environment, the process gets *only* that environment. That means the
processes created here didn't have, for example, `PATH` defined.

If the child process is being created from a script file with a
`#!/usr/bin/env something` shebang, the lack of the `PATH` environment
variable makes `env` - which uses the `execvp` function under the hood -
get a list of predefined paths using `confstr(_CS_PATH)`. This list
includes only paths where POSIX standard utils live, which usually means
some subset of {`/bin`, `/usr/bin`}.

If the `something` on the shebang does not live in one of these, the
child will fail to run with a

    /usr/bin/env: something: No such file or directory

This is a problem because scripts being run by `dpat` usually have a
`#!/usr/bin/env node` line, but `node` may be installed in a number of
different places, specially if something like `nvm` is being used.

This commit makes the child inherit the parent environment by using
`Object.assign` to create a copy of the parent env with some extra
variables. The parent env isn't modified and the child should happily
execute.