### PR TITLE
release-0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project is following [Semantic Versioning](http://semver.org)
 
 ## [Unreleased][]
 
+### Fixed
+
+ - removed obsolete property named `enabled` from the custom field manifest definition 
+ - add required property named `title` to the custom field manifest definition
+
+
 ## [0.7.0][] - 2017-10-05
 
 ### Added

--- a/src/main/javascript/Manifest/Schemas.js
+++ b/src/main/javascript/Manifest/Schemas.js
@@ -391,9 +391,9 @@ const Schemas = Object.assign({}, {
           type: { type: "string", "enum": ["dataJson", "dataList", "data", "date", "dateTime", "text", "textarea", "textEmail", "textUrl", "toggle", "choice"] },
           attachedTo: { type: "string", "enum": ["ticket", "person", "organization"] },
           alias: { type: "string", pattern: "^[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*" },
-          enabled: { type: "boolean" }
+          title: { type: "string", pattern: ".+"}
         },
-        required: [ "type", "alias", "enabled", "attachedTo" ],
+        required: [ "type", "alias", "attachedTo", "title" ],
       },
 
       author: {

--- a/src/test/resources/valid-v2.3.0-manifest.manifest.json
+++ b/src/test/resources/valid-v2.3.0-manifest.manifest.json
@@ -112,13 +112,13 @@
     {
       "type": "dataJson",
       "alias": "trello-cards",
-      "enabled": true,
+      "title": "Trello cards",
       "attachedTo": "ticket"
     },
     {
       "type": "date",
       "alias": "adate",
-      "enabled": true,
+      "title": "A date",
       "attachedTo": "ticket"
     }
   ],

--- a/src/test/resources/valid-v2.3.0-manifest.package.json
+++ b/src/test/resources/valid-v2.3.0-manifest.package.json
@@ -97,13 +97,13 @@
       {
         "type": "dataJson",
         "alias": "trello-cards",
-        "enabled": true,
+        "title": "Trello cards",
         "attachedTo": "ticket"
       },
       {
         "type": "date",
         "alias": "adate",
-        "enabled": true,
+        "title": "A date",
         "attachedTo": "ticket"
       }
     ],


### PR DESCRIPTION
 removed obsolete property named `enabled` from the custom field manifest definition
 add required property named `title` to the custom field manifest definition